### PR TITLE
add support for CFFS transactions

### DIFF
--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -40,6 +40,7 @@
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/resource.h>
+#include <sys/ioctl.h>
 #include <strings.h>
 
 #include "filebench.h"
@@ -80,6 +81,7 @@ static int fb_lfs_stat(char *, struct stat64 *);
 static int fb_lfs_fstat(fb_fdesc_t *, struct stat64 *);
 static int fb_lfs_access(const char *, int);
 static void fb_lfs_recur_rm(char *);
+static int fb_lfs_ioctl(fb_fdesc_t *, unsigned long, void *);
 
 static fsplug_func_t fb_lfs_funcs =
 {
@@ -107,7 +109,8 @@ static fsplug_func_t fb_lfs_funcs =
 	fb_lfs_stat,		/* stat */
 	fb_lfs_fstat,		/* fstat */
 	fb_lfs_access,		/* access */
-	fb_lfs_recur_rm		/* recursive rm */
+	fb_lfs_recur_rm,	/* recursive rm */
+	fb_lfs_ioctl		/* ioctl */
 };
 
 #ifdef HAVE_AIO
@@ -682,4 +685,13 @@ static int
 fb_lfs_access(const char *path, int amode)
 {
 	return (access(path, amode));
+}
+
+/*
+ * Does an ioctl() call on a file.
+ */
+static int
+fb_lfs_ioctl(fb_fdesc_t *fd, unsigned long request, void *argp)
+{
+	return (ioctl(fd->fd_num, request, argp));
 }

--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -479,16 +479,20 @@ fb_lfsflow_aiowait(threadflow_t *threadflow, flowop_t *flowop)
 /*
  * Does an open64 of a file. Inserts the file descriptor number returned
  * by open() into the supplied filebench fd. Returns FILEBENCH_OK on
- * successs, and FILEBENCH_ERROR on failure.
+ * successs, FILEBENCH_AGAIN on IO error and FILEBENCH_ERROR on failure.
  */
 
 static int
 fb_lfs_open(fb_fdesc_t *fd, char *path, int flags, int perms)
 {
-	if ((fd->fd_num = open64(path, flags, perms)) < 0)
+	if ((fd->fd_num = open64(path, flags, perms)) < 0) {
+		if (errno == EIO) {
+			return (FILEBENCH_AGAIN);
+		}
 		return (FILEBENCH_ERROR);
-	else
-		return (FILEBENCH_OK);
+	}
+
+	return (FILEBENCH_OK);
 }
 
 /*

--- a/filebench.h
+++ b/filebench.h
@@ -188,5 +188,6 @@ static inline int sigignore(int sig) {
 #define	FILEBENCH_OK	 0
 #define	FILEBENCH_ERROR -1
 #define	FILEBENCH_NORSC -2
+#define	FILEBENCH_AGAIN	-3
 
 #endif	/* _FB_FILEBENCH_H */

--- a/fileset.c
+++ b/fileset.c
@@ -306,7 +306,10 @@ fileset_alloc_file(filesetentry_t *entry)
 	trust_tree = avd_get_bool(fileset->fs_trust_tree);
 	if ((entry->fse_flags & FSE_REUSING) && (trust_tree ||
 	    (FB_STAT(path, &sb) == 0))) {
-		if ((ret = FB_OPEN(&fdesc, path, fs_readonly ? O_RDONLY : O_RDWR, 0)) != FILEBENCH_OK) {
+		do {
+			ret = FB_OPEN(&fdesc, path, fs_readonly ? O_RDONLY : O_RDWR, 0);
+		} while (ret == FILEBENCH_AGAIN);
+		if (ret != FILEBENCH_OK) {
 			filebench_log(LOG_INFO,
 			    "Attempted but failed to Re-use file %s",
 			    path);

--- a/flowop_library.c
+++ b/flowop_library.c
@@ -1660,11 +1660,15 @@ flowoplib_createfile(threadflow_t *threadflow, flowop_t *flowop)
 
 	if ((err = flowoplib_pickfile(&file, flowop,
 	    FILESET_PICKNOEXIST, 0)) != FILEBENCH_OK) {
-		filebench_log(LOG_DEBUG_SCRIPT,
-		    "flowop %s failed to pick file from fileset %s",
-		    flowop->fo_name,
-		    avd_get_str(flowop->fo_fileset->fs_name));
-		return (err);
+		// fallback to existing files
+		if ((err = flowoplib_pickfile(&file, flowop,
+		    FILESET_PICKEXISTS, 0)) != FILEBENCH_OK) {
+			filebench_log(LOG_DEBUG_SCRIPT,
+			    "flowop %s failed to pick file from fileset %s",
+			    flowop->fo_name,
+			    avd_get_str(flowop->fo_fileset->fs_name));
+			return (err);
+		}
 	}
 
 	threadflow->tf_fse[fd] = file;

--- a/fsplug.h
+++ b/fsplug.h
@@ -75,6 +75,7 @@ typedef struct fsplug_func_s {
 	int (*fsp_fstat)(fb_fdesc_t *, struct stat64 *);
 	int (*fsp_access)(const char *, int);
 	void (*fsp_recur_rm)(char *);
+	int (*fsp_ioctl)(fb_fdesc_t *, unsigned long, void *);
 } fsplug_func_t;
 
 extern fsplug_func_t *fs_functions_vec;
@@ -142,5 +143,8 @@ extern fsplug_func_t *fs_functions_vec;
 
 #define	FB_SYMLINK(name1, name2) \
 	(*fs_functions_vec->fsp_symlink)(name1, name2)
+
+#define	FB_IOCTL(fdesc, request, argp) \
+	(*fs_functions_vec->fsp_ioctl)(fdesc, request, argp)
 
 #endif /* _FB_FSPLUG_H */

--- a/threadflow.c
+++ b/threadflow.c
@@ -57,7 +57,7 @@ static threadflow_t *threadflow_define_common(procflow_t *procflow,
  * shared memory is desired, then increments the amount of shared
  * memory needed by the amount specified in the threadflow's
  * tf_memsize parameter. The thread starts in routine
- * flowop_start() with a poineter to the threadflow supplied
+ * flowop_start() with a pointer to the threadflow supplied
  * as the argument.
  */
 static int


### PR DESCRIPTION
This change enables Filebench benchmarks to use CFFS transactions. Therefore, two additional flowops 'opendir' and 'ioctl' have been added. These can be used to send the Begin, Commit and Abort commands to CFFS via an open directory handle.
Furthermore, the Filebench error handling has been enhanced with the error state FILEBENCH_AGAIN, which requests a restart of the threads flowop loop, emulating the restart of a transaction. FILEBENCH_AGAIN is triggered by EIO errors, which are issued by CFFS on outdated server reads.
The change also prevents benchmarks aborts when running out of unallocated files for createfile. In this case an already allocated file is re-created.